### PR TITLE
Moesi update

### DIFF
--- a/ptlsim/cache/moesiLogic.cpp
+++ b/ptlsim/cache/moesiLogic.cpp
@@ -489,9 +489,9 @@ struct MOESICacheControllerBuilder : public ControllerBuilder
             MemoryHierarchy& mem, const char *name) {
         CacheController *cont = new CacheController(coreid, name, &mem, (Memory::CacheType)(type));
 
-        MOESILogic *mesi = new MOESILogic(cont, cont->get_stats(), &mem);
+        MOESILogic *moesi = new MOESILogic(cont, cont->get_stats(), &mem);
 
-        cont->set_coherence_logic(mesi);
+        cont->set_coherence_logic(moesi);
 
         bool is_private = false;
         if (!mem.get_machine().get_option(name, "private", is_private)) {

--- a/ptlsim/cache/moesiLogic.h
+++ b/ptlsim/cache/moesiLogic.h
@@ -52,18 +52,18 @@ namespace CoherentCache {
     enum MOESITransations {
         II=0, IM, IO, IE, IS,
         MI, MM, MO, ME, MS,
+        OI, OM, OO, OE, OS,
         EI, EM, EO, EE, ES,
         SI, SM, SO, SE, SS,
-        OI, OM, OO, OE, OS,
         NUM_MOESI_STATE_TRANS,
     };
 
     static int MOESITransTable[NUM_MOESI_STATES][NUM_MOESI_STATES] = {
         {II, IM, IO, IE, IS},
         {MI, MM, MO, ME, MS},
+        {OI, OM, OO, OE, OS},
         {EI, EM, EO, EE, ES},
         {SI, SM, SO, SE, SS},
-        {OI, OM, OO, OE, OS},
     };
 
     static const char* MOESIStateNames[NUM_MOESI_STATES] = {


### PR DESCRIPTION
I added the missing O\* states in the transition table and found a spelling error in the Cache Controller Builder code where the variable was mesi instead of moesi.
