### PR TITLE
Updated Scons to use different levels of debugging with progressively

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -30,7 +30,7 @@ if sys.version_info < (2, 5):
     sys.exit(-1)
 
 
-SetOption('num_jobs', num_cpus * 2)
+SetOption('num_jobs', num_cpus + 1)
 print("running with -j%s" % GetOption('num_jobs'))
 
 # Our build order is as following:

--- a/ptlsim/SConstruct
+++ b/ptlsim/SConstruct
@@ -4,6 +4,7 @@ import os
 import platform
 import subprocess
 import config_helper
+import re
 
 # List of subdirectories where we have source code
 dirs = ['cache', 'core', 'lib', 'sim', 'stats', 'tools', 'x86']
@@ -29,13 +30,22 @@ env['CPPPATH'].append("%s/%s" % (qemu_dir, "x86_64-softmmu"))
 optimization_defs = '-fno-trapping-math -fstack-protector -fno-exceptions '
 optimization_defs += '-fno-rtti -funroll-loops -fstrict-aliasing '
 
+GCC_VERSION = subprocess.Popen([env['CC'], '-dumpversion'],
+				stdout=subprocess.PIPE).communicate()[0].strip()
+GCC_MAJOR_MINOR_VERSION = re.match(r'\d*\.\d+',GCC_VERSION).group() #e.g. returns 4.2 for 4.2.2
 debug = ARGUMENTS.get('debug', 0)
 if int(debug):
-    env.Append(CCFLAGS = '-g')
 
     # If debugging level is 1 then do optimize
     if int(debug) == 1:
-        env.Append(CCFLAGS = '-O')
+    	env.Append(CCFLAGS = '-g')
+    elif int(debug) == 2: #For more detailed debugging information
+		env.Append(CCFLAGS = '-ggdb3')
+		env.Append(CCFLAGS = '-g3')
+		if float(GCC_MAJOR_MINOR_VERSION) >= 4.8:
+			env.Append(CCFLAGS = '-Og')
+		else: #Possibly slow
+			env.Append(CCFLAGS = '-O')
 
     # Enable tests
     env.Append(CCFLAGS = '-DENABLE_TESTS')
@@ -46,8 +56,7 @@ if int(debug):
     env['tests'] = True
 
 else:
-    env.Append(CCFLAGS = '-g3')
-    env.Append(CCFLAGS = '-O3 -march=native -mtune=native')
+    env.Append(CCFLAGS = '-O3 -march=native')
     env.Append(CCFLAGS = '-DDISABLE_ASSERT')
     env.Append(CCFLAGS = '-DDISABLE_LOGGING')
     env.Append(CCFLAGS = optimization_defs)

--- a/qemu/SConstruct
+++ b/qemu/SConstruct
@@ -6,6 +6,8 @@ Import('qemu_target')
 Import('ptlsim_lib')
 Import('plugins')
 Import('ptlsim_inc_dir')
+import subprocess
+import re
 env = qemu_env
 target = qemu_target
 
@@ -23,19 +25,26 @@ env['CPPPATH'].append(ptlsim_inc_dir)
 env.Append(CCFLAGS = "-MMD -MP -DNEED_CPU_H")
 env.Append(CCFLAGS = "-DMARSS_QEMU")
 
+GCC_VERSION = subprocess.Popen([env['CC'], '-dumpversion'],
+    stdout=subprocess.PIPE).communicate()[0].strip()
+GCC_MAJOR_MINOR_VERSION = re.match(r'\d*\.\d+',GCC_VERSION).group() #e.g. returns 4.2 for 4.2.2
+
 num_sim_cores = ARGUMENTS.get('c', 1)
 env.Append(CCFLAGS = '-DNUM_SIM_CORES=%d' % int(num_sim_cores))
 
 debug = ARGUMENTS.get('debug', 0)
 if int(debug):
-    env.Append(CCFLAGS = '-g')
-
-    # If debugging level is 1 then do optimize
     if int(debug) == 1:
-        env.Append(CCFLAGS = '-O')
+        env.Append(CCFLAGS = '-g')
+    elif int(debug) == 2:
+        env.Append(CCFLAGS = '-ggdb3')
+        env.Append(CCFLAGS = '-g3')
+        if float(GCC_MAJOR_MINOR_VERSION) >= 4.8:
+            env.Append(CCFLAGS = '-Og')
+        else:
+            env.Append(CCFLAGS = '-O')
 else:
-    env.Append(CCFLAGS = '-g3')
-    env.Append(CCFLAGS = '-O3 -march=native -mtune=native')
+    env.Append(CCFLAGS = '-O3 -march=native')
 
 google_perftools = ARGUMENTS.get('gperf', None)
 if google_perftools != None:


### PR DESCRIPTION
Previously, scons was putting debugging information into a non-debugging build, this has been fixed along with a suggestion to handle a new debugging option in GCC 4.8, but still allow for older versions to work correctly.

scons by itself now creates a very small binary
scons debug=1 creates a binary roughly 4 times larger
scons debug=2 creates a binary roughtly 7 times larger
