### PR TITLE
Output timestamp in ns to periodic stats by default

### DIFF
--- a/ptlsim/stats/statsBuilder.cpp
+++ b/ptlsim/stats/statsBuilder.cpp
@@ -358,7 +358,8 @@ ostream& StatsBuilder::dump_header(ostream &os) const
 {
     if (rootNode->is_dump_periodic())
     {
-        os << "sim_cycle";
+        os << "sim_cycle,";
+        os << "time_ns";
         rootNode->dump_header(os);
         os << "\n";
     }
@@ -394,7 +395,8 @@ ostream& StatsBuilder::dump_periodic(ostream& os, W64 cycle) const
     sub_periodic_stats(*temp_stats, *temp2_stats);
 
     if(rootNode->is_dump_periodic()) {
-        os << cycle;
+        os << cycle << ",";
+        os << simcycles_to_ns(cycle);
         rootNode->dump_periodic(os, temp_stats);
         os << "\n";
     }


### PR DESCRIPTION
Outputting sim_cycle alone makes it hard to figure out the actual time
stamp since it will be dependent on the frequency selected; this will
make it easier to match up stats to other periodic data (such as time
stats from an external simulator)
