### PR TITLE
Build # of cores string with preprocessor

### DIFF
--- a/ptlsim/sim/ptlsim.cpp
+++ b/ptlsim/sim/ptlsim.cpp
@@ -366,7 +366,7 @@ static void print_banner(ostream& os) {
   os << "//  Git branch '" << stringify(GITBRANCH) << "' on date " << stringify(GITDATE) << " (HEAD: " << stringify(GITCOMMIT) << ")" << endl;
   os << "//  Built " << __DATE__ << " " << __TIME__ << " on " << stringify(BUILDHOST) << " using gcc-" <<
     stringify(__GNUC__) << "." << stringify(__GNUC_MINOR__) << endl;
-  os << "//  With " << stringify(NUM_SIM_CORES) << " simulated cores" << endl;
+  os << "//  With " stringify(NUM_SIM_CORES) " simulated cores" << endl;
   os << "//  Running on " << hostinfo.nodename << "." << hostinfo.domainname << endl;
   os << "//  " << endl;
   os << endl;


### PR DESCRIPTION
This fixes commit df021d1922d65c4de811b65d9cbed22ebd51115c which
was meant to put the number of cores string into the binary.
However, the problem is that the string has to be built
by the preprocessor (and not at runtime as it is now) or else it doesn't
work as intended:

current version:
$ strings qemu/qemu-system-x86_64 | grep cores
 simulated cores

this patch:
$ strings qemu/qemu-system-x86_64 | grep cores
//  With 8 simulated cores
