### PR TITLE
SConstruct: remove bogus assumptions

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -104,7 +104,7 @@ else:
 base_env['ENV'] = os.environ
 # To specify your c++ compiler uncomment this line and
 # set the correct path to your c++ compiler
-base_env['CXX'] = "g++"
+base_env['CXX'] = "c++"
 base_env['CC'] = base_env['CXX']
 
 base_env['config'] = config_helper.parse_config(config_file, debug=config_debug)

--- a/qemu/SConfigure
+++ b/qemu/SConfigure
@@ -560,10 +560,10 @@ usb = "linux"
 linux_user = True
 
 # Check target OS
-if conf.CheckCPUDefine("__linux__"):
+if conf.CheckCPUDefine("__linux__") or conf.CheckCPUDefine("__FreeBSD__"):
     env['targetos'] = "Linux"
 else:
-    print("ERROR: Unsupported target OS, use Linux")
+    print("ERROR: Unsupported target OS, use FreeBSD Linux")
     exit_with_error()
 
 CFLAGS = "%s -fno-strict-aliasing" % (env['CCFLAGS'])

--- a/qemu/SConstruct
+++ b/qemu/SConstruct
@@ -300,11 +300,11 @@ else:
 env['CPPPATH'].append("%s/fpu" % env['source_path'])
 
 op_helper_obj = env.Object('%s/op_helper.c' % target_path, 
-        CCFLAGS = env['CCFLAGS'] + HELPER_CFLAGS)
+        CCFLAGS = env['CCFLAGS'] + [HELPER_CFLAGS])
 helper_obj = env.Object('%s/helper.c' % target_path,
-        CCFLAGS = env['CCFLAGS'] + HELPER_CFLAGS)
+        CCFLAGS = env['CCFLAGS'] + [HELPER_CFLAGS])
 cpu_exec_obj = env.Object('cpu-exec.c', 
-        CCFLAGS = env['CCFLAGS'] + HELPER_CFLAGS)
+        CCFLAGS = env['CCFLAGS'] + [HELPER_CFLAGS])
 
 cpu_emu_objs += " %s/op_helper.o %s/helper.o" % (target_path, target_path)
 cpu_emu_objs += " cpu-exec.o"

--- a/qemu/configure
+++ b/qemu/configure
@@ -85,7 +85,7 @@ audio_drv_list=""
 audio_card_list="ac97 es1370 sb16 hda"
 audio_possible_cards="ac97 es1370 sb16 cs4231a adlib gus hda"
 block_drv_whitelist=""
-host_cc="gcc"
+host_cc="cc"
 helper_cflags=""
 libs_softmmu=""
 libs_tools=""
@@ -212,7 +212,7 @@ done
 # Using uname is really, really broken.  Once we have the right set of checks
 # we can eliminate it's usage altogether
 
-cc="${cross_prefix}${CC-gcc}"
+cc="${cross_prefix}${CC-cc}"
 ar="${cross_prefix}${AR-ar}"
 objcopy="${cross_prefix}${OBJCOPY-objcopy}"
 ld="${cross_prefix}${LD-ld}"

--- a/qemu/os-posix.c
+++ b/qemu/os-posix.c
@@ -27,11 +27,13 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/types.h>
+#include <sys/sysctl.h>
 #include <sys/wait.h>
 /*needed for MAP_POPULATE before including qemu-options.h */
 #include <sys/mman.h>
 #include <pwd.h>
 #include <libgen.h>
+
 
 /* Needed early for CONFIG_BSD etc. */
 #include "config-host.h"

--- a/qemu/qemu-timer.h
+++ b/qemu/qemu-timer.h
@@ -10,6 +10,10 @@
 #include <mmsystem.h>
 #endif
 
+#ifdef __FreeBSD__
+#include <osreldate.h>
+#endif
+
 /* timers */
 
 typedef struct QEMUClock QEMUClock;


### PR DESCRIPTION
Don't presume that 'gcc' exists on the target system.
Instead use 'cc'.  Ideally we could use 'c99' or 'c11' (POSIX
requires 'c99').

On systems 'gcc' may be spelled 'gcc48' or otherwise.
