### PR TITLE
Yaml

### DIFF
--- a/ptlsim/SConstruct
+++ b/ptlsim/SConstruct
@@ -30,6 +30,9 @@ env['CPPPATH'].append("%s/%s" % (qemu_dir, "x86_64-softmmu"))
 optimization_defs = '-fno-trapping-math -fstack-protector -fno-exceptions '
 optimization_defs += '-fno-rtti -funroll-loops -fstrict-aliasing '
 
+env.Append(CCFLAGS = ' -fdiagnostics-color=always ')
+env.Append(CCFLAGS = ' -std=gnu++11 ')
+
 GCC_VERSION = subprocess.Popen([env['CC'], '-dumpversion'],
 				stdout=subprocess.PIPE).communicate()[0].strip()
 GCC_MAJOR_MINOR_VERSION = re.match(r'\d*\.\d+',GCC_VERSION).group() #e.g. returns 4.2 for 4.2.2

--- a/ptlsim/lib/yaml/emitter.h
+++ b/ptlsim/lib/yaml/emitter.h
@@ -80,7 +80,8 @@ namespace YAML
 		
 	private:
 		ostream m_stream;
-		std::auto_ptr <EmitterState> m_pState;
+		//std::auto_ptr <EmitterState> m_pState;
+		std::unique_ptr <EmitterState> m_pState;
 	};
 	
 	template <typename T>

--- a/ptlsim/lib/yaml/emitter.h
+++ b/ptlsim/lib/yaml/emitter.h
@@ -80,7 +80,6 @@ namespace YAML
 		
 	private:
 		ostream m_stream;
-		//std::auto_ptr <EmitterState> m_pState;
 		std::unique_ptr <EmitterState> m_pState;
 	};
 	

--- a/ptlsim/lib/yaml/emitterstate.cpp
+++ b/ptlsim/lib/yaml/emitterstate.cpp
@@ -29,14 +29,11 @@ namespace YAML
 			_PopGroup();
 	}
 	
-	//std::auto_ptr <EmitterState::Group> EmitterState::_PopGroup()
 	std::unique_ptr <EmitterState::Group> EmitterState::_PopGroup()
 	{
 		if(m_groups.empty())
-			//return std::auto_ptr <Group> (0);
 			return std::unique_ptr <Group> (nullptr);
 		
-		//std::auto_ptr <Group> pGroup(m_groups.top());
 		std::unique_ptr <Group> pGroup(m_groups.top());
 		m_groups.pop();
 		return pGroup;
@@ -63,7 +60,7 @@ namespace YAML
 		unsigned lastIndent = (m_groups.empty() ? 0 : m_groups.top()->indent);
 		m_curIndent += lastIndent;
 		
-		std::auto_ptr <Group> pGroup(new Group(type));
+		std::unique_ptr <Group> pGroup(new Group(type));
 		
 		// transfer settings (which last until this group is done)
 		pGroup->modifiedSettings = m_modifiedSettings;
@@ -83,7 +80,6 @@ namespace YAML
 		
 		// get rid of the current group
 		{
-			//std::auto_ptr <Group> pFinishedGroup = _PopGroup();
 			std::unique_ptr <Group> pFinishedGroup = _PopGroup();
 			if(pFinishedGroup->type != type)
 				return SetError(ErrorMsg::UNMATCHED_GROUP_TAG);

--- a/ptlsim/lib/yaml/emitterstate.cpp
+++ b/ptlsim/lib/yaml/emitterstate.cpp
@@ -29,12 +29,15 @@ namespace YAML
 			_PopGroup();
 	}
 	
-	std::auto_ptr <EmitterState::Group> EmitterState::_PopGroup()
+	//std::auto_ptr <EmitterState::Group> EmitterState::_PopGroup()
+	std::unique_ptr <EmitterState::Group> EmitterState::_PopGroup()
 	{
 		if(m_groups.empty())
-			return std::auto_ptr <Group> (0);
+			//return std::auto_ptr <Group> (0);
+			return std::unique_ptr <Group> (nullptr);
 		
-		std::auto_ptr <Group> pGroup(m_groups.top());
+		//std::auto_ptr <Group> pGroup(m_groups.top());
+		std::unique_ptr <Group> pGroup(m_groups.top());
 		m_groups.pop();
 		return pGroup;
 	}
@@ -80,7 +83,8 @@ namespace YAML
 		
 		// get rid of the current group
 		{
-			std::auto_ptr <Group> pFinishedGroup = _PopGroup();
+			//std::auto_ptr <Group> pFinishedGroup = _PopGroup();
+			std::unique_ptr <Group> pFinishedGroup = _PopGroup();
 			if(pFinishedGroup->type != type)
 				return SetError(ErrorMsg::UNMATCHED_GROUP_TAG);
 		}

--- a/ptlsim/lib/yaml/emitterstate.h
+++ b/ptlsim/lib/yaml/emitterstate.h
@@ -178,7 +178,6 @@ namespace YAML
 			SettingChanges modifiedSettings;
 		};
 		
-		//std::auto_ptr <Group> _PopGroup();
 		std::unique_ptr <Group> _PopGroup();
 		
 		std::stack <Group *> m_groups;

--- a/ptlsim/lib/yaml/emitterstate.h
+++ b/ptlsim/lib/yaml/emitterstate.h
@@ -178,7 +178,8 @@ namespace YAML
 			SettingChanges modifiedSettings;
 		};
 		
-		std::auto_ptr <Group> _PopGroup();
+		//std::auto_ptr <Group> _PopGroup();
+		std::unique_ptr <Group> _PopGroup();
 		
 		std::stack <Group *> m_groups;
 		unsigned m_curIndent;

--- a/ptlsim/lib/yaml/map.cpp
+++ b/ptlsim/lib/yaml/map.cpp
@@ -14,11 +14,8 @@ namespace YAML
 	Map::Map(const node_map& data)
 	{
 		for(node_map::const_iterator it=data.begin();it!=data.end();++it) {
-			//std::auto_ptr<Node> pKey = it->first->Clone();
-			//std::auto_ptr<Node> pValue = it->second->Clone();
 			std::unique_ptr<Node> pKey = std::move(it->first->Clone());
 			std::unique_ptr<Node> pValue = std::move(it->second->Clone());
-			//AddEntry(pKey, pValue);
       AddEntry(std::move(pKey), std::move(pValue));
 		}
 	}
@@ -92,7 +89,6 @@ namespace YAML
 				break;
 			}
 
-			//std::auto_ptr <Node> pKey(new Node), pValue(new Node);
 			std::unique_ptr <Node> pKey(new Node), pValue(new Node);
 			
 			// grab key (if non-null)
@@ -108,7 +104,6 @@ namespace YAML
 			}
 
 			//AddEntry(pKey, pValue);
-      AddEntry(std::move(pKey), std::move(pValue));
 		}
 
 		state.PopCollectionType(ParserState::BLOCK_MAP);
@@ -131,7 +126,6 @@ namespace YAML
 				break;
 			}
 			
-			//std::auto_ptr <Node> pKey(new Node), pValue(new Node);
 			std::unique_ptr <Node> pKey(new Node), pValue(new Node);
 
 			// grab key (if non-null)
@@ -153,7 +147,6 @@ namespace YAML
 			else if(nextToken.type != Token::FLOW_MAP_END)
 				throw ParserException(nextToken.mark, ErrorMsg::END_OF_MAP_FLOW);
 
-			//AddEntry(pKey, pValue);
       AddEntry(std::move(pKey), std::move(pValue));
 		}
 
@@ -165,7 +158,6 @@ namespace YAML
 	void Map::ParseCompact(Scanner *pScanner, ParserState& state)
 	{
 		state.PushCollectionType(ParserState::COMPACT_MAP);
-		//std::auto_ptr <Node> pKey(new Node), pValue(new Node);
 		std::unique_ptr <Node> pKey(new Node), pValue(new Node);
 
 		// grab key
@@ -178,7 +170,6 @@ namespace YAML
 			pValue->Parse(pScanner, state);
 		}
 			
-		//AddEntry(pKey, pValue);
     AddEntry(std::move(pKey), std::move(pValue));
 		state.PopCollectionType(ParserState::COMPACT_MAP);
 	}
@@ -188,19 +179,16 @@ namespace YAML
 	void Map::ParseCompactWithNoKey(Scanner *pScanner, ParserState& state)
 	{
 		state.PushCollectionType(ParserState::COMPACT_MAP);
-		//std::auto_ptr <Node> pKey(new Node), pValue(new Node);
 		std::unique_ptr <Node> pKey(new Node), pValue(new Node);
 
 		// grab value
 		pScanner->pop();
 		pValue->Parse(pScanner, state);
 
-		//AddEntry(pKey, pValue);
     AddEntry(std::move(pKey), std::move(pValue));
 		state.PopCollectionType(ParserState::COMPACT_MAP);
 	}
 	
-	//void Map::AddEntry(std::auto_ptr<Node> pKey, std::auto_ptr<Node> pValue)
 	void Map::AddEntry(std::unique_ptr<Node> pKey, std::unique_ptr<Node> pValue)
 	{
 		node_map::const_iterator it = m_data.find(pKey.get());

--- a/ptlsim/lib/yaml/map.cpp
+++ b/ptlsim/lib/yaml/map.cpp
@@ -14,9 +14,12 @@ namespace YAML
 	Map::Map(const node_map& data)
 	{
 		for(node_map::const_iterator it=data.begin();it!=data.end();++it) {
-			std::auto_ptr<Node> pKey = it->first->Clone();
-			std::auto_ptr<Node> pValue = it->second->Clone();
-			AddEntry(pKey, pValue);
+			//std::auto_ptr<Node> pKey = it->first->Clone();
+			//std::auto_ptr<Node> pValue = it->second->Clone();
+			std::unique_ptr<Node> pKey = std::move(it->first->Clone());
+			std::unique_ptr<Node> pValue = std::move(it->second->Clone());
+			//AddEntry(pKey, pValue);
+      AddEntry(std::move(pKey), std::move(pValue));
 		}
 	}
 
@@ -89,7 +92,8 @@ namespace YAML
 				break;
 			}
 
-			std::auto_ptr <Node> pKey(new Node), pValue(new Node);
+			//std::auto_ptr <Node> pKey(new Node), pValue(new Node);
+			std::unique_ptr <Node> pKey(new Node), pValue(new Node);
 			
 			// grab key (if non-null)
 			if(token.type == Token::KEY) {
@@ -103,7 +107,8 @@ namespace YAML
 				pValue->Parse(pScanner, state);
 			}
 
-			AddEntry(pKey, pValue);
+			//AddEntry(pKey, pValue);
+      AddEntry(std::move(pKey), std::move(pValue));
 		}
 
 		state.PopCollectionType(ParserState::BLOCK_MAP);
@@ -126,7 +131,8 @@ namespace YAML
 				break;
 			}
 			
-			std::auto_ptr <Node> pKey(new Node), pValue(new Node);
+			//std::auto_ptr <Node> pKey(new Node), pValue(new Node);
+			std::unique_ptr <Node> pKey(new Node), pValue(new Node);
 
 			// grab key (if non-null)
 			if(token.type == Token::KEY) {
@@ -147,7 +153,8 @@ namespace YAML
 			else if(nextToken.type != Token::FLOW_MAP_END)
 				throw ParserException(nextToken.mark, ErrorMsg::END_OF_MAP_FLOW);
 
-			AddEntry(pKey, pValue);
+			//AddEntry(pKey, pValue);
+      AddEntry(std::move(pKey), std::move(pValue));
 		}
 
 		state.PopCollectionType(ParserState::FLOW_MAP);
@@ -158,7 +165,8 @@ namespace YAML
 	void Map::ParseCompact(Scanner *pScanner, ParserState& state)
 	{
 		state.PushCollectionType(ParserState::COMPACT_MAP);
-		std::auto_ptr <Node> pKey(new Node), pValue(new Node);
+		//std::auto_ptr <Node> pKey(new Node), pValue(new Node);
+		std::unique_ptr <Node> pKey(new Node), pValue(new Node);
 
 		// grab key
 		pScanner->pop();
@@ -170,7 +178,8 @@ namespace YAML
 			pValue->Parse(pScanner, state);
 		}
 			
-		AddEntry(pKey, pValue);
+		//AddEntry(pKey, pValue);
+    AddEntry(std::move(pKey), std::move(pValue));
 		state.PopCollectionType(ParserState::COMPACT_MAP);
 	}
 	
@@ -179,17 +188,20 @@ namespace YAML
 	void Map::ParseCompactWithNoKey(Scanner *pScanner, ParserState& state)
 	{
 		state.PushCollectionType(ParserState::COMPACT_MAP);
-		std::auto_ptr <Node> pKey(new Node), pValue(new Node);
+		//std::auto_ptr <Node> pKey(new Node), pValue(new Node);
+		std::unique_ptr <Node> pKey(new Node), pValue(new Node);
 
 		// grab value
 		pScanner->pop();
 		pValue->Parse(pScanner, state);
 
-		AddEntry(pKey, pValue);
+		//AddEntry(pKey, pValue);
+    AddEntry(std::move(pKey), std::move(pValue));
 		state.PopCollectionType(ParserState::COMPACT_MAP);
 	}
 	
-	void Map::AddEntry(std::auto_ptr<Node> pKey, std::auto_ptr<Node> pValue)
+	//void Map::AddEntry(std::auto_ptr<Node> pKey, std::auto_ptr<Node> pValue)
+	void Map::AddEntry(std::unique_ptr<Node> pKey, std::unique_ptr<Node> pValue)
 	{
 		node_map::const_iterator it = m_data.find(pKey.get());
 		if(it != m_data.end())

--- a/ptlsim/lib/yaml/map.h
+++ b/ptlsim/lib/yaml/map.h
@@ -45,7 +45,8 @@ namespace YAML
 		void ParseCompact(Scanner *pScanner, ParserState& state);
 		void ParseCompactWithNoKey(Scanner *pScanner, ParserState& state);
 		
-		void AddEntry(std::auto_ptr<Node> pKey, std::auto_ptr<Node> pValue);
+		//void AddEntry(std::auto_ptr<Node> pKey, std::auto_ptr<Node> pValue);
+		void AddEntry(std::unique_ptr<Node> pKey, std::unique_ptr<Node> pValue);
 
 	private:
 		node_map m_data;

--- a/ptlsim/lib/yaml/map.h
+++ b/ptlsim/lib/yaml/map.h
@@ -45,7 +45,6 @@ namespace YAML
 		void ParseCompact(Scanner *pScanner, ParserState& state);
 		void ParseCompactWithNoKey(Scanner *pScanner, ParserState& state);
 		
-		//void AddEntry(std::auto_ptr<Node> pKey, std::auto_ptr<Node> pValue);
 		void AddEntry(std::unique_ptr<Node> pKey, std::unique_ptr<Node> pValue);
 
 	private:

--- a/ptlsim/lib/yaml/node.cpp
+++ b/ptlsim/lib/yaml/node.cpp
@@ -46,14 +46,11 @@ namespace YAML
 		m_tag.clear();
 	}
 	
-	//std::auto_ptr<Node> Node::Clone() const
 	std::unique_ptr<Node> Node::Clone() const
 	{
 		if(m_alias)
 			throw std::runtime_error("yaml-cpp: Can't clone alias");  // TODO: what to do about aliases?
 		
-		//return std::auto_ptr<Node> (new Node(m_mark, m_anchor, m_tag, m_pContent));
-		//return std::unique_ptr<Node> (new Node(m_mark, m_anchor, m_tag, m_pContent));
     std::unique_ptr<Node> p (new Node(m_mark, m_anchor, m_tag, m_pContent));
     return std::move(p);
 	}

--- a/ptlsim/lib/yaml/node.cpp
+++ b/ptlsim/lib/yaml/node.cpp
@@ -46,12 +46,16 @@ namespace YAML
 		m_tag.clear();
 	}
 	
-	std::auto_ptr<Node> Node::Clone() const
+	//std::auto_ptr<Node> Node::Clone() const
+	std::unique_ptr<Node> Node::Clone() const
 	{
 		if(m_alias)
 			throw std::runtime_error("yaml-cpp: Can't clone alias");  // TODO: what to do about aliases?
 		
-		return std::auto_ptr<Node> (new Node(m_mark, m_anchor, m_tag, m_pContent));
+		//return std::auto_ptr<Node> (new Node(m_mark, m_anchor, m_tag, m_pContent));
+		//return std::unique_ptr<Node> (new Node(m_mark, m_anchor, m_tag, m_pContent));
+    std::unique_ptr<Node> p (new Node(m_mark, m_anchor, m_tag, m_pContent));
+    return std::move(p);
 	}
 
 	void Node::Parse(Scanner *pScanner, ParserState& state)

--- a/ptlsim/lib/yaml/node.h
+++ b/ptlsim/lib/yaml/node.h
@@ -31,7 +31,6 @@ namespace YAML
 		~Node();
 
 		void Clear();
-		//std::auto_ptr<Node> Clone() const;
 		std::unique_ptr<Node> Clone() const;
 		void Parse(Scanner *pScanner, ParserState& state);
 

--- a/ptlsim/lib/yaml/node.h
+++ b/ptlsim/lib/yaml/node.h
@@ -31,7 +31,8 @@ namespace YAML
 		~Node();
 
 		void Clear();
-		std::auto_ptr<Node> Clone() const;
+		//std::auto_ptr<Node> Clone() const;
+		std::unique_ptr<Node> Clone() const;
 		void Parse(Scanner *pScanner, ParserState& state);
 
 		CONTENT_TYPE GetType() const;

--- a/ptlsim/lib/yaml/parser.h
+++ b/ptlsim/lib/yaml/parser.h
@@ -38,8 +38,8 @@ namespace YAML
 		void HandleTagDirective(const Token& token);
 
 	private:
-		std::auto_ptr<Scanner> m_pScanner;
-		std::auto_ptr<ParserState> m_pState;
+		std::unique_ptr<Scanner> m_pScanner;
+		std::unique_ptr<ParserState> m_pState;
 	};
 }
 

--- a/ptlsim/lib/yaml/scanner.cpp
+++ b/ptlsim/lib/yaml/scanner.cpp
@@ -289,7 +289,7 @@ namespace YAML
 		if(InFlowContext())
 			return 0;
 		
-		std::auto_ptr<IndentMarker> pIndent(new IndentMarker(column, type));
+		std::unique_ptr<IndentMarker> pIndent(new IndentMarker(column, type));
 		IndentMarker& indent = *pIndent;
 		const IndentMarker& lastIndent = *m_indents.top();
 

--- a/ptlsim/lib/yaml/setting.h
+++ b/ptlsim/lib/yaml/setting.h
@@ -19,7 +19,6 @@ namespace YAML
 		Setting(): m_value() {}
 		
 		const T get() const { return m_value; }
-		//std::auto_ptr <SettingChangeBase> set(const T& value);
 		std::unique_ptr <SettingChangeBase> set(const T& value);
 		void restore(const Setting<T>& oldSetting) {
 			m_value = oldSetting.get();
@@ -55,9 +54,7 @@ namespace YAML
 	};
 
 	template <typename T>
-	//inline std::auto_ptr <SettingChangeBase> Setting<T>::set(const T& value) {
 	inline std::unique_ptr <SettingChangeBase> Setting<T>::set(const T& value) {
-		//std::auto_ptr <SettingChangeBase> pChange(new SettingChange<T> (this));
 		std::unique_ptr <SettingChangeBase> pChange(new SettingChange<T> (this));
 		m_value = value;
 		return pChange;
@@ -82,7 +79,6 @@ namespace YAML
 				(*it)->pop();
 		}
 		
-		//void push(std::auto_ptr <SettingChangeBase> pSettingChange) {
 		void push(std::unique_ptr <SettingChangeBase> pSettingChange) {
 			m_settingChanges.push_back(pSettingChange.release());
 		}

--- a/ptlsim/lib/yaml/setting.h
+++ b/ptlsim/lib/yaml/setting.h
@@ -19,7 +19,8 @@ namespace YAML
 		Setting(): m_value() {}
 		
 		const T get() const { return m_value; }
-		std::auto_ptr <SettingChangeBase> set(const T& value);
+		//std::auto_ptr <SettingChangeBase> set(const T& value);
+		std::unique_ptr <SettingChangeBase> set(const T& value);
 		void restore(const Setting<T>& oldSetting) {
 			m_value = oldSetting.get();
 		}
@@ -54,8 +55,10 @@ namespace YAML
 	};
 
 	template <typename T>
-	inline std::auto_ptr <SettingChangeBase> Setting<T>::set(const T& value) {
-		std::auto_ptr <SettingChangeBase> pChange(new SettingChange<T> (this));
+	//inline std::auto_ptr <SettingChangeBase> Setting<T>::set(const T& value) {
+	inline std::unique_ptr <SettingChangeBase> Setting<T>::set(const T& value) {
+		//std::auto_ptr <SettingChangeBase> pChange(new SettingChange<T> (this));
+		std::unique_ptr <SettingChangeBase> pChange(new SettingChange<T> (this));
 		m_value = value;
 		return pChange;
 	}
@@ -79,7 +82,8 @@ namespace YAML
 				(*it)->pop();
 		}
 		
-		void push(std::auto_ptr <SettingChangeBase> pSettingChange) {
+		//void push(std::auto_ptr <SettingChangeBase> pSettingChange) {
+		void push(std::unique_ptr <SettingChangeBase> pSettingChange) {
 			m_settingChanges.push_back(pSettingChange.release());
 		}
 		


### PR DESCRIPTION
The yaml library uses auto_ptr, which is deprecated in C++11, and gcc6 complains about it. This converts the auto_ptr to unique_ptr and uses move semantics where necessary.