### PR TITLE
ptlsim/qemu: Disable compiler optimizations

### DIFF
--- a/ptlsim/SConstruct
+++ b/ptlsim/SConstruct
@@ -28,7 +28,7 @@ env['CPPPATH'].append("%s/%s" % (qemu_dir, "fpu"))
 env['CPPPATH'].append("%s/%s" % (qemu_dir, "x86_64-softmmu"))
 
 optimization_defs = '-fno-trapping-math -fstack-protector -fno-exceptions '
-optimization_defs += '-fno-rtti -funroll-loops -fstrict-aliasing '
+optimization_defs += '-fno-rtti -fno-strict-aliasing '
 
 env.Append(CCFLAGS = ' -fdiagnostics-color=always ')
 env.Append(CCFLAGS = ' -std=gnu++11 ')
@@ -56,7 +56,7 @@ if int(debug):
     env['tests'] = True
 
 else:
-    env.Append(CCFLAGS = '-O3 -march=native')
+    env.Append(CCFLAGS = '-O0 -march=native')
     env.Append(CCFLAGS = '-DDISABLE_ASSERT')
     env.Append(CCFLAGS = '-DDISABLE_LOGGING')
     env.Append(CCFLAGS = optimization_defs)

--- a/qemu/SConstruct
+++ b/qemu/SConstruct
@@ -22,6 +22,7 @@ env['CPPPATH'] = []
 env['CPPPATH'].append([".", "..", target_path, env['source_path']])
 env['CPPPATH'].append(target['dir'])
 env['CPPPATH'].append(ptlsim_inc_dir)
+env.Append(CCFLAGS = "-fno-strict-aliasing")
 env.Append(CCFLAGS = "-MMD -MP -DNEED_CPU_H")
 env.Append(CCFLAGS = "-DMARSS_QEMU")
 
@@ -40,7 +41,7 @@ if int(debug):
         env.Append(CCFLAGS = '-g3')
         env.Append(CCFLAGS = '-O0')
 else:
-    env.Append(CCFLAGS = '-O3 -march=native')
+    env.Append(CCFLAGS = '-O0 -march=native')
 
 google_perftools = ARGUMENTS.get('gperf', None)
 if google_perftools != None:


### PR DESCRIPTION
This is unfortunate, but after obtaining the default,
official MARSS image and running the FFT simulation with
./start_sim and ./stop_sim, it seems broken. It errors
out with:

```
Switching to simulation
ptlsim_ptlcall_init: mapped PTLcall MMIO page at phys 0x8fffff000, virt
0x7f9520458000
PTLCALL type PTLCALL_ENQUEUE
MARSSx86::Command received : -run
Warning: only one action (from -run, -stop, -kill) can be specified at
once
```

I'm running Debian Bullseye (stable) with the default GCC
and build tools shipped with it, so nothing fancy here.

Knowing that `ptlsim`, has a lot of reliance on undefined
behavior throughout its codebase, I disabled compiler
optimizations and everything began working as expected
again.

There's practical ways to fuzz for what's breaking things
here, but this was a rather obvious error. There could also
be subtle ones that invalidate or produce poor/bad/fake
simulation results. Until uses of undefined behavior are
squashed or at least somewhat fuzzed for, disable compiler
optimizations to prevent surprises.

Signed-off-by: Tyler J. Stachecki <stachecki.tyler@gmail.com>